### PR TITLE
Clarify pattern usage is not a problem

### DIFF
--- a/sections/always_use_a_design_pattern.md
+++ b/sections/always_use_a_design_pattern.md
@@ -32,4 +32,4 @@ Always use the pragmatic approach:
 >
 > -- Collins English Dictionary, Complete and Unabridged, 12th Edition 2014
 
-**The wrong way**: Thinking of patterns when solving problems. ![Thumbs down](img/thumbs-down.png)
+**The wrong way**: Looking for a pattern to solve a problem. ![Thumbs down](img/thumbs-down.png)


### PR DESCRIPTION
Initially, this said to me that when I'm solving a problem, it's incorrect for me to think: "Hey, that pattern would help here when implementing that".

I've made what you mean clearer as it was too open for interpretation before ("when" changed to "to", effectively).
